### PR TITLE
Débugger bouton supprimer ChannelChat

### DIFF
--- a/client/RealTalk/src/components/sidebar.jsx
+++ b/client/RealTalk/src/components/sidebar.jsx
@@ -6,6 +6,7 @@ function Sidebar({ nickname, onSelectConversation }) {
   const [activeTab, setActiveTab] = useState('channels'); // 'channels' ou 'conversations'
   const [channels, setChannels] = useState([]);// Liste des canaux disponibles
   const [joinedChannels, setJoinedChannels] = useState([]);// Liste des canaux auxquels l'utilisateur a adhéré
+  const [joinedChannelsWithAuthor, setJoinedChannelsWithAuthor] = useState([]);// Liste des canaux avec info auteur
   const [privateConversations, setPrivateConversations] = useState([]);// Liste des conversations privées
   const [showActions, setShowActions] = useState(false);// État pour afficher/masquer les actions
 
@@ -14,10 +15,20 @@ function Sidebar({ nickname, onSelectConversation }) {
   // Récupérer la liste des canaux disponibles
   socket.emit('/list', '', (data) => {
     setChannels(data);
-  });
-  // Récupérer les canaux auxquels l'utilisateur a déjà adhéré
-  socket.emit('/mychannels', (data) => {
-    setJoinedChannels(data);  // data = [channelName, ...]
+    
+    // Récupérer les canaux auxquels l'utilisateur a déjà adhéré après avoir reçu la liste
+    socket.emit('/mychannels', (joinedData) => {
+      setJoinedChannels(joinedData);  // data = [channelName, ...]
+      // Enrichir avec les infos d'auteur depuis la liste complète
+      const enrichedChannels = joinedData.map(channelName => {
+        const channelInfo = data.find(ch => ch.name === channelName);
+        return {
+          name: channelName,
+          author: channelInfo ? channelInfo.author : 'Inconnu'
+        };
+      });
+      setJoinedChannelsWithAuthor(enrichedChannels);
+    });
   });
   // Récupérer les conversations privées
   socket.emit('/privates', (data) => {
@@ -30,13 +41,25 @@ function Sidebar({ nickname, onSelectConversation }) {
   // Écouter les événements de jointure de canaux 
   socket.on('/join', (channel) => {
     setJoinedChannels((prev) => [...new Set([...prev, channel])]);
+    // Mettre à jour aussi la liste enrichie
+    setJoinedChannelsWithAuthor((prev) => {
+      const channelInfo = channels.find(ch => ch.name === channel);
+      const newChannel = {
+        name: channel,
+        author: channelInfo ? channelInfo.author : 'Inconnu'
+      };
+      const exists = prev.find(ch => ch.name === channel);
+      return exists ? prev : [...prev, newChannel];
+    });
   });
   // Écouter les événements de sortie de canaux
   socket.on('/quit', (channelName) => {
     setJoinedChannels((prev) => prev.filter((name) => name !== channelName));
+    setJoinedChannelsWithAuthor((prev) => prev.filter((ch) => ch.name !== channelName));
   });
   socket.on('/force_quit', (channelName) => {
     setJoinedChannels((prev) => prev.filter((name) => name !== channelName));
+    setJoinedChannelsWithAuthor((prev) => prev.filter((ch) => ch.name !== channelName));
   });
 
   // Nettoyage des écouteurs d'événements
@@ -79,7 +102,7 @@ function Sidebar({ nickname, onSelectConversation }) {
         // 👉 Rejoindre automatiquement le canal juste après l’avoir créé
         socket.emit('/join', channelName, (joinResponse) => {
           if (joinResponse.startsWith('✅')) {
-            onSelectConversation({ type: 'channel', name: channelName });
+            onSelectConversation({ type: 'channel', name: channelName, author: nickname });
           } else {
             alert(joinResponse);
           }
@@ -91,13 +114,13 @@ function Sidebar({ nickname, onSelectConversation }) {
   };
 
 // /join
-  const handleJoinChannel = (channelName) => {
+  const handleJoinChannel = (channelName, author) => {
     const confirmJoin = window.confirm(`Rejoindre le canal #${channelName} ?`);
     if (!confirmJoin) return;
       socket.emit('/join', channelName, (response) => {
         alert(response);
         if (response.startsWith('✅')) {
-          onSelectConversation({ type: 'channel', name: channelName });
+          onSelectConversation({ type: 'channel', name: channelName, author });
         }
       });
 
@@ -116,7 +139,7 @@ function Sidebar({ nickname, onSelectConversation }) {
             {channels.map(({ name, author }) => (
               <li key={name} style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '0.5rem' }}>
                 <span>#{name} <i style={{ fontSize: '0.8em', color: '#666' }}>par {author}</i></span>
-                <button onClick={() => handleJoinChannel(name)} title={`Rejoindre #${name}`}>+</button>
+                <button onClick={() => handleJoinChannel(name, author)} title={`Rejoindre #${name}`}>+</button>
               </li>
             ))}
           </ul>
@@ -125,9 +148,9 @@ function Sidebar({ nickname, onSelectConversation }) {
 
         {activeTab === 'conversations' && (
           <ul>
-            {joinedChannels.map((channel) => (
-              <li key={channel} style={{ cursor: 'pointer' }} onClick={() => onSelectConversation({ type: 'channel', name: channel })}>
-                #{channel}
+            {joinedChannelsWithAuthor.map(({ name, author }) => (
+              <li key={name} style={{ cursor: 'pointer' }} onClick={() => onSelectConversation({ type: 'channel', name, author })}>
+                #{name} <i style={{ fontSize: '0.8em', color: '#666' }}>par {author}</i>
               </li>
             ))}
             {privateConversations.map((user) => (


### PR DESCRIPTION
Propagate channel author information from sidebar to enable delete button.

The delete button in `ChannelChat.jsx` is conditionally rendered based on the `author === nickname` check. However, when a channel was selected from the 'conversations' tab in the sidebar, the `author` prop was not being passed, leading to the button not appearing. This PR modifies the sidebar to correctly retrieve and pass the author information for joined channels, ensuring the delete button displays as intended.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-19cfae67-d13c-450f-aba5-7fc651581c53) · [Cursor](https://cursor.com/background-agent?bcId=bc-19cfae67-d13c-450f-aba5-7fc651581c53)

Learn more about [Background Agents](https://docs.cursor.com/background-agents)